### PR TITLE
Handle null DirectoryName in cleanup script

### DIFF
--- a/scripts/FriendlyCleanup.ps1
+++ b/scripts/FriendlyCleanup.ps1
@@ -1,0 +1,34 @@
+$banner = @"
+   ____                 _       ____            _       _
+  / ___|___  _ __   ___| |_    / ___|___  _ __ | |_ ___| |__
+ | |   / _ \| '_ \ / _ \ __|  | |   / _ \| '_ \| __/ __| '_ \
+ | |__| (_) | | | |  __/ |_   | |__| (_) | | | | || (__| | | |
+  \____\___/|_| |_|\___|\__|   \____\___/|_| |_|\__\___|_| |_|
+          Friendly File Cleanup • For 🕡 SECURITY & 💖 FRIENDSHIP
+"@
+Write-Host $banner -ForegroundColor Cyan
+
+# Configuration
+$sourcePath = "C:\\Users\\kaitw\\Documents"
+$logFolder = "C:\\Users\\kaitw\\ScriptGraveyard"
+$cutoffDays = 30
+$now = Get-Date
+$cutoffDate = $now.AddDays(-$cutoffDays)
+$logCsv = "C:\\Users\\kaitw\\CleanupLog_$($now.ToString('yyyyMMdd_HHmmss')).csv"
+$logData = @()
+
+# Excluded folders (case-insensitive match)
+$excludedFolders = @("D:\\blink", "D:\\blink_backup")
+$excludedFoldersLower = $excludedFolders | ForEach-Object { $_.ToLower() }
+
+# Ensure destination exists
+if (-not (Test-Path $logFolder)) {
+    New-Item -ItemType Directory -Path $logFolder | Out-Null
+}
+
+# Get old files excluding Blink folders
+$oldFiles = Get-ChildItem -Path $sourcePath -Recurse -File | Where-Object {
+    $_.LastWriteTime -lt $cutoffDate -and
+    $_.DirectoryName -and
+    -not ($excludedFoldersLower -contains $_.DirectoryName.ToLower())
+}


### PR DESCRIPTION
## Summary
- add FriendlyCleanup script
- avoid calling `.ToLower()` on `$_.DirectoryName` when it's null

## Testing
- `pwsh -NoProfile -Command "Get-ChildItem scripts"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6be008b5c832faf5eb2f9b9d97221