### PR TITLE
Add friendly cleanup automation with Matt messaging

### DIFF
--- a/scripts/FriendlyCleanup.ps1
+++ b/scripts/FriendlyCleanup.ps1
@@ -32,3 +32,38 @@ $oldFiles = Get-ChildItem -Path $sourcePath -Recurse -File | Where-Object {
     $_.DirectoryName -and
     -not ($excludedFoldersLower -contains $_.DirectoryName.ToLower())
 }
+
+# Move the files and collect log data
+foreach ($file in $oldFiles) {
+    $relativePath = $file.FullName.Substring($sourcePath.Length).TrimStart('\')
+    $destination = Join-Path $logFolder $relativePath
+    $destDir = Split-Path $destination -Parent
+    if (-not (Test-Path $destDir)) {
+        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+    }
+    Move-Item -Path $file.FullName -Destination $destination -Force
+    $logData += [PSCustomObject]@{
+        FileName      = $file.Name
+        OriginalPath  = $file.FullName
+        NewPath       = $destination
+        LastWriteTime = $file.LastWriteTime
+    }
+}
+
+# Write log to CSV
+if ($logData.Count -gt 0) {
+    $logData | Export-Csv -NoTypeInformation -Path $logCsv
+    Write-Host "Moved $($logData.Count) files. Log saved to $logCsv" -ForegroundColor Green
+
+    # Optional: email the log to Matt
+    $mattEmail = "matt@example.com"       # <-- replace with Matt's real email
+    $smtpServer = "smtp.example.com"      # <-- replace with your SMTP server
+    try {
+        Send-MailMessage -To $mattEmail -From "$env:USERNAME@example.com" -Subject "Cleanup Log" -Body "Files moved to $logFolder" -Attachments $logCsv -SmtpServer $smtpServer
+        Write-Host "Cleanup log emailed to Matt." -ForegroundColor Cyan
+    } catch {
+        Write-Host "Failed to email Matt: $_" -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "No files older than $cutoffDays days were found." -ForegroundColor Yellow
+}

--- a/scripts/MessageMatt.ps1
+++ b/scripts/MessageMatt.ps1
@@ -1,0 +1,10 @@
+param(
+    [string]$Subject = "Hello Matt",
+    [string]$Body = "Just checking in!"
+)
+
+Add-Type -AssemblyName System.Web
+$encodedSubject = [System.Web.HttpUtility]::UrlEncode($Subject)
+$encodedBody = [System.Web.HttpUtility]::UrlEncode($Body)
+$mailto = "mailto:matt@example.com?subject=$encodedSubject&body=$encodedBody"
+Start-Process $mailto


### PR DESCRIPTION
## Summary
- fix cleanup script to exclude folders, move old files, log actions, and email log to Matt
- add MessageMatt script to quickly draft emails to Matt

## Testing
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `pwsh scripts/FriendlyCleanup.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8c74d074832f80aa8eee6185df6b