### PR TITLE
Add Tool Chest screens with encrypted local storage

### DIFF
--- a/src/ToolChestNavigator.tsx
+++ b/src/ToolChestNavigator.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import ToolChestScreen from './screens/ToolChestScreen';
+import StrategyFormScreen from './screens/StrategyFormScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function ToolChestNavigator() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="ToolChest" component={ToolChestScreen} />
+        <Stack.Screen
+          name="StrategyForm"
+          component={StrategyFormScreen}
+          options={{ title: 'Strategy' }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+

--- a/src/screens/StrategyFormScreen.tsx
+++ b/src/screens/StrategyFormScreen.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+import { Strategy, saveStrategy, deleteStrategy } from '../storage/strategyStorage';
+import uuid from 'react-native-uuid';
+
+interface Props {
+  navigation: any;
+  route: { params?: { strategy?: Strategy } };
+}
+
+export default function StrategyFormScreen({ navigation, route }: Props) {
+  const existing = route.params?.strategy;
+  const [text, setText] = useState(existing?.text ?? '');
+
+  const onSave = async () => {
+    const strategy: Strategy = {
+      id: existing?.id ?? (uuid.v4() as string),
+      text,
+    };
+    await saveStrategy(strategy);
+    navigation.goBack();
+  };
+
+  const onDelete = async () => {
+    if (existing) {
+      await deleteStrategy(existing.id);
+    }
+    navigation.goBack();
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <TextInput
+        value={text}
+        onChangeText={setText}
+        placeholder="Coping strategy"
+        style={{ borderWidth: 1, padding: 8, marginBottom: 16 }}
+      />
+      <Button title="Save" onPress={onSave} />
+      {existing ? <Button title="Delete" onPress={onDelete} /> : null}
+    </View>
+  );
+}
+

--- a/src/screens/ToolChestScreen.tsx
+++ b/src/screens/ToolChestScreen.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, FlatList, TouchableOpacity } from 'react-native';
+import { Strategy, loadStrategies } from '../storage/strategyStorage';
+
+interface Props {
+  navigation: any;
+}
+
+export default function ToolChestScreen({ navigation }: Props) {
+  const [strategies, setStrategies] = useState<Strategy[]>([]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('focus', () => {
+      loadStrategies().then(setStrategies);
+    });
+    return unsubscribe;
+  }, [navigation]);
+
+  const renderItem = ({ item }: { item: Strategy }) => (
+    <TouchableOpacity
+      onPress={() => navigation.navigate('StrategyForm', { strategy: item })}
+    >
+      <Text style={{ padding: 16 }}>{item.text}</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={{ flex: 1 }}>
+      <FlatList
+        data={strategies}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        ListEmptyComponent={<Text style={{ padding: 16 }}>No strategies yet.</Text>}
+      />
+      <Button
+        title="Add Strategy"
+        onPress={() => navigation.navigate('StrategyForm')}
+      />
+    </View>
+  );
+}
+

--- a/src/storage/strategyStorage.ts
+++ b/src/storage/strategyStorage.ts
@@ -1,0 +1,33 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import CryptoJS from 'crypto-js';
+
+const MASTER_CONTENT_KEY = 'tool_chest_master_key';
+
+export type Strategy = {
+  id: string;
+  text: string;
+};
+
+const STORAGE_PREFIX = 'strategy:';
+
+export async function saveStrategy(strategy: Strategy): Promise<void> {
+  const encrypted = CryptoJS.AES.encrypt(strategy.text, MASTER_CONTENT_KEY).toString();
+  await AsyncStorage.setItem(`${STORAGE_PREFIX}${strategy.id}`, encrypted);
+}
+
+export async function deleteStrategy(id: string): Promise<void> {
+  await AsyncStorage.removeItem(`${STORAGE_PREFIX}${id}`);
+}
+
+export async function loadStrategies(): Promise<Strategy[]> {
+  const keys = await AsyncStorage.getAllKeys();
+  const strategyKeys = keys.filter((k) => k.startsWith(STORAGE_PREFIX));
+  const stores = await AsyncStorage.multiGet(strategyKeys);
+  return stores.map(([key, value]) => ({
+    id: key.replace(STORAGE_PREFIX, ''),
+    text: value
+      ? CryptoJS.AES.decrypt(value, MASTER_CONTENT_KEY).toString(CryptoJS.enc.Utf8)
+      : '',
+  }));
+}
+


### PR DESCRIPTION
## Summary
- add storage helpers to encrypt coping strategies with a master key and persist them in AsyncStorage
- create Tool Chest listing screen and form for adding/editing strategies
- wire screens into a stack navigator for basic screen flow

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a79610b4832f802a904800d8391d